### PR TITLE
🧩 [Fix] 관심 키워드 엔티티 생성에 따른 회원가입, 목록조회 기능 수정 및 회원 프로필 조회 기능 구현

### DIFF
--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/controller/MemberController.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import com.goojakgyo.goojakgyo.member.dto.GoogleProfileDto;
 import com.goojakgyo.goojakgyo.member.dto.KakaoProfileDto;
 import com.goojakgyo.goojakgyo.member.dto.MemberListReqDto;
 import com.goojakgyo.goojakgyo.member.dto.MemberLoginReqDto;
+import com.goojakgyo.goojakgyo.member.dto.MemberProfileResDto;
 import com.goojakgyo.goojakgyo.member.dto.MemberSaveReqDto;
 import com.goojakgyo.goojakgyo.member.dto.NaverProfileDto;
 import com.goojakgyo.goojakgyo.member.dto.OauthSaveReqDto;
@@ -24,6 +25,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -170,10 +172,22 @@ public class MemberController {
     return new ResponseEntity<>(loginInfo, HttpStatus.OK);
   }
 
-  @GetMapping("/list")
-  public ResponseEntity<?> memberList() {
-    List<MemberListReqDto> dtos = memberService.findAll();
+  @GetMapping("/list/mentor")
+  public ResponseEntity<?> mentorList() {
+    List<MemberListReqDto> dtos = memberService.findMentors();
     return new ResponseEntity<>(dtos, HttpStatus.OK);
+  }
+
+  @GetMapping("/list/mentee")
+  public ResponseEntity<?> menteeList() {
+    List<MemberListReqDto> dtos = memberService.findMentees();
+    return new ResponseEntity<>(dtos, HttpStatus.OK);
+  }
+
+  @GetMapping("/{memberId}")
+  public ResponseEntity<?> memberProfile(@PathVariable Long memberId) {
+    MemberProfileResDto dto = memberService.getMemberProfile(memberId);
+    return new ResponseEntity<>(dto, HttpStatus.OK);
   }
 
 }

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/controller/MemberController.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/controller/MemberController.java
@@ -6,7 +6,7 @@ import com.goojakgyo.goojakgyo.member.domain.SocialType;
 import com.goojakgyo.goojakgyo.member.dto.AccessTokenDto;
 import com.goojakgyo.goojakgyo.member.dto.GoogleProfileDto;
 import com.goojakgyo.goojakgyo.member.dto.KakaoProfileDto;
-import com.goojakgyo.goojakgyo.member.dto.MemberListReqDto;
+import com.goojakgyo.goojakgyo.member.dto.MemberListResDto;
 import com.goojakgyo.goojakgyo.member.dto.MemberLoginReqDto;
 import com.goojakgyo.goojakgyo.member.dto.MemberProfileResDto;
 import com.goojakgyo.goojakgyo.member.dto.MemberSaveReqDto;
@@ -174,13 +174,13 @@ public class MemberController {
 
   @GetMapping("/list/mentor")
   public ResponseEntity<?> mentorList() {
-    List<MemberListReqDto> dtos = memberService.findMentors();
+    List<MemberListResDto> dtos = memberService.findMentors();
     return new ResponseEntity<>(dtos, HttpStatus.OK);
   }
 
   @GetMapping("/list/mentee")
   public ResponseEntity<?> menteeList() {
-    List<MemberListReqDto> dtos = memberService.findMentees();
+    List<MemberListResDto> dtos = memberService.findMentees();
     return new ResponseEntity<>(dtos, HttpStatus.OK);
   }
 

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/domain/Keyword.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/domain/Keyword.java
@@ -1,14 +1,10 @@
 package com.goojakgyo.goojakgyo.member.domain;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,8 +23,4 @@ public class Keyword {
 
   @Column(nullable = false, unique = true)
   private String keywordName;
-
-  @Builder.Default
-  @OneToMany(mappedBy = "keyword", cascade = CascadeType.ALL, orphanRemoval = true)
-  private List<MemberKeyword> memberKeywords = new ArrayList<>();
 }

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/domain/Keyword.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/domain/Keyword.java
@@ -1,0 +1,34 @@
+package com.goojakgyo.goojakgyo.member.domain;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class Keyword {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, unique = true)
+  private String keywordName;
+
+  @Builder.Default
+  @OneToMany(mappedBy = "keyword", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<MemberKeyword> memberKeywords = new ArrayList<>();
+}

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/domain/Member.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.goojakgyo.goojakgyo.member.domain;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -7,6 +8,9 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -31,6 +35,13 @@ public class Member {
   private String email;
 
   private String password;
+
+  @Builder.Default
+  private String profileImageUrl = "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSmYmaWrQ2kwplFb1FN1a07DmEKCAiIA4j31TfkvVr4STcOqQP7M-hITB3gPuckOSdRb8I&usqp=CAU";
+
+  public void updateProfileImageUrl(String profileImageUrl) {
+    this.profileImageUrl = profileImageUrl;
+  }
   
   // 학교 정보
   @Column(nullable = false)
@@ -44,12 +55,20 @@ public class Member {
   
   // Role
   @Enumerated(EnumType.STRING)
-  @Builder.Default
-  private Role role = Role.USER;
+  private Role role;
 
   // Social Login 정보
   @Enumerated(EnumType.STRING)
   private SocialType socialType;
 
   private String socialId;
+
+  // Keword 정보
+  @Builder.Default
+  @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+  private List<MemberKeyword> memberKeywords = new ArrayList<>();
+
+  public void addMemberKeyword(MemberKeyword memberKeyword) {
+    memberKeywords.add(memberKeyword);
+  }
 }

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/domain/MemberKeyword.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/domain/MemberKeyword.java
@@ -1,0 +1,48 @@
+package com.goojakgyo.goojakgyo.member.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Table(name = "member_keyword")
+public class MemberKeyword {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id")
+  private Member member;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "keyword_id")
+  private Keyword keyword;
+
+  private MemberKeyword(Member member, Keyword keyword) {
+    this.member = member;
+    this.keyword = keyword;
+  }
+
+  public static MemberKeyword of(Member member, Keyword keyword) {
+    return MemberKeyword.builder()
+        .member(member)
+        .keyword(keyword)
+        .build();
+  }
+
+}

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/domain/Role.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/domain/Role.java
@@ -2,5 +2,5 @@ package com.goojakgyo.goojakgyo.member.domain;
 
 // Role
 public enum Role {
-  ADMIN, USER
+  USER, MENTOR, MENTEE, ADMIN
 }

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/dto/MemberListResDto.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/dto/MemberListResDto.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class MemberListReqDto {
+public class MemberListResDto {
   private Long Id;
   private String name;
   private String email;

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/dto/MemberProfileResDto.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/dto/MemberProfileResDto.java
@@ -1,17 +1,24 @@
 package com.goojakgyo.goojakgyo.member.dto;
 
-
+import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class MemberListReqDto {
-  private Long Id;
+@Builder
+public class MemberProfileResDto {
+  private Long id;
   private String name;
   private String email;
+
   private String univName;
   private String major;
+  private String studentId;
+
+  private String profileImageUrl;
+  private List<String> keywords;
 }

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/dto/MemberSaveReqDto.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/dto/MemberSaveReqDto.java
@@ -1,7 +1,7 @@
 package com.goojakgyo.goojakgyo.member.dto;
 
-// 회원가입시 요청되는 dto
-
+import com.goojakgyo.goojakgyo.member.domain.Role;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,4 +17,7 @@ public class MemberSaveReqDto {
   private String univName;
   private String major;
   private String studentId;
+  private Role role;
+
+  private List<Long> keywordIds;
 }

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/dto/OauthSaveReqDto.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/dto/OauthSaveReqDto.java
@@ -1,6 +1,8 @@
 package com.goojakgyo.goojakgyo.member.dto;
 
+import com.goojakgyo.goojakgyo.member.domain.Role;
 import com.goojakgyo.goojakgyo.member.domain.SocialType;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,4 +19,7 @@ public class OauthSaveReqDto {
   private String univName;
   private String major;
   private String studentId;
+  private Role role;
+
+  private List<Long> keywordIds;
 }

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/repository/KeywordRepository.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/repository/KeywordRepository.java
@@ -1,0 +1,10 @@
+package com.goojakgyo.goojakgyo.member.repository;
+
+import com.goojakgyo.goojakgyo.member.domain.Keyword;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface KeywordRepository extends JpaRepository<Keyword, Long> {
+
+}

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/repository/MemberRepository.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/repository/MemberRepository.java
@@ -1,6 +1,8 @@
 package com.goojakgyo.goojakgyo.member.repository;
 
 import com.goojakgyo.goojakgyo.member.domain.Member;
+import com.goojakgyo.goojakgyo.member.domain.Role;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -11,4 +13,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
   Optional<Member> findByEmail(String email);
 
   Optional<Member> findBySocialId(String socialId);
+
+  List<Member> findByRole(Role role);
 }

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/service/MemberService.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/service/MemberService.java
@@ -1,16 +1,22 @@
 package com.goojakgyo.goojakgyo.member.service;
 
+import com.goojakgyo.goojakgyo.member.domain.Keyword;
 import com.goojakgyo.goojakgyo.member.domain.Member;
-import com.goojakgyo.goojakgyo.member.domain.SocialType;
+import com.goojakgyo.goojakgyo.member.domain.MemberKeyword;
+import com.goojakgyo.goojakgyo.member.domain.Role;
 import com.goojakgyo.goojakgyo.member.dto.MemberListReqDto;
 import com.goojakgyo.goojakgyo.member.dto.MemberLoginReqDto;
+import com.goojakgyo.goojakgyo.member.dto.MemberProfileResDto;
 import com.goojakgyo.goojakgyo.member.dto.MemberSaveReqDto;
 import com.goojakgyo.goojakgyo.member.dto.OauthSaveReqDto;
+import com.goojakgyo.goojakgyo.member.repository.KeywordRepository;
 import com.goojakgyo.goojakgyo.member.repository.MemberRepository;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -18,10 +24,12 @@ import org.springframework.stereotype.Service;
 @Transactional
 public class MemberService {
   private final MemberRepository memberRepository;
+  private final KeywordRepository keywordRepository;
   private final PasswordEncoder passwordEncoder;
 
-  public MemberService(MemberRepository memberRepository, PasswordEncoder passwordEncoder) {
+  public MemberService(MemberRepository memberRepository, KeywordRepository keywordRepository, PasswordEncoder passwordEncoder) {
     this.memberRepository = memberRepository;
+    this.keywordRepository = keywordRepository;
     this.passwordEncoder = passwordEncoder;
   }
 
@@ -31,6 +39,8 @@ public class MemberService {
       throw new IllegalArgumentException("이미 존재하는 이메일입니다.");
     }
 
+    List<Keyword> selectedKeywords = keywordRepository.findAllById(memberSaveReqDto.getKeywordIds());
+
     Member newMember = Member.builder()
         .name(memberSaveReqDto.getName())
         .email(memberSaveReqDto.getEmail())
@@ -38,7 +48,13 @@ public class MemberService {
         .univName(memberSaveReqDto.getUnivName())
         .major(memberSaveReqDto.getMajor())
         .studentId(memberSaveReqDto.getStudentId())
+        .role(memberSaveReqDto.getRole())
         .build();
+
+    for (Keyword keyword : selectedKeywords) {
+      MemberKeyword memberKeyword = MemberKeyword.of(newMember, keyword);
+      newMember.addMemberKeyword(memberKeyword);
+    }
 
     return memberRepository.save(newMember);
   }
@@ -54,15 +70,34 @@ public class MemberService {
     return member;
   }
 
-  public List<MemberListReqDto> findAll() {
-    List<Member> members = memberRepository.findAll();
+  public List<MemberListReqDto> findMentors() {
+    List<Member> mentors = memberRepository.findByRole(Role.MENTOR);
     List<MemberListReqDto> memberListReqDtos = new ArrayList<>();
 
-    for (Member m : members) {
+    for (Member m : mentors) {
       MemberListReqDto memberListReqDto = new MemberListReqDto();
       memberListReqDto.setId(m.getId());
       memberListReqDto.setName(m.getName());
       memberListReqDto.setEmail(m.getEmail());
+      memberListReqDto.setUnivName(m.getUnivName());
+      memberListReqDto.setMajor(m.getMajor());
+      memberListReqDtos.add(memberListReqDto);
+    }
+
+    return memberListReqDtos;
+  }
+
+  public List<MemberListReqDto> findMentees() {
+    List<Member> mentees = memberRepository.findByRole(Role.MENTEE);
+    List<MemberListReqDto> memberListReqDtos = new ArrayList<>();
+
+    for (Member m : mentees) {
+      MemberListReqDto memberListReqDto = new MemberListReqDto();
+      memberListReqDto.setId(m.getId());
+      memberListReqDto.setName(m.getName());
+      memberListReqDto.setEmail(m.getEmail());
+      memberListReqDto.setUnivName(m.getUnivName());
+      memberListReqDto.setMajor(m.getMajor());
       memberListReqDtos.add(memberListReqDto);
     }
 
@@ -84,9 +119,33 @@ public class MemberService {
         .univName(oauthSaveReqDto.getUnivName())
         .major(oauthSaveReqDto.getMajor())
         .studentId(oauthSaveReqDto.getStudentId())
+        .role(oauthSaveReqDto.getRole())
         .build();
 
+    List<Keyword> selectedKeywords = keywordRepository.findAllById(oauthSaveReqDto.getKeywordIds());
+    for (Keyword keyword : selectedKeywords) {
+      MemberKeyword memberKeyword = MemberKeyword.of(newMember, keyword);
+      newMember.addMemberKeyword(memberKeyword);
+    }
+
     return memberRepository.save(newMember);
+  }
+
+  public MemberProfileResDto getMemberProfile(Long memberId) {
+    Member member = memberRepository.findById(memberId).orElseThrow(() -> new IllegalArgumentException("해당 회원이 존재하지 않습니다."));
+
+    List<String> keywordNames = member.getMemberKeywords().stream().map(MemberKeyword::getKeyword).map(k -> k.getKeywordName()).collect(Collectors.toList());
+
+    return MemberProfileResDto.builder()
+        .id(member.getId())
+        .name(member.getName())
+        .email(member.getEmail())
+        .profileImageUrl(member.getProfileImageUrl())
+        .univName(member.getUnivName())
+        .major(member.getMajor())
+        .studentId(member.getStudentId())
+        .keywords(keywordNames)
+        .build();
   }
 
 }

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/service/MemberService.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/service/MemberService.java
@@ -4,7 +4,7 @@ import com.goojakgyo.goojakgyo.member.domain.Keyword;
 import com.goojakgyo.goojakgyo.member.domain.Member;
 import com.goojakgyo.goojakgyo.member.domain.MemberKeyword;
 import com.goojakgyo.goojakgyo.member.domain.Role;
-import com.goojakgyo.goojakgyo.member.dto.MemberListReqDto;
+import com.goojakgyo.goojakgyo.member.dto.MemberListResDto;
 import com.goojakgyo.goojakgyo.member.dto.MemberLoginReqDto;
 import com.goojakgyo.goojakgyo.member.dto.MemberProfileResDto;
 import com.goojakgyo.goojakgyo.member.dto.MemberSaveReqDto;
@@ -15,7 +15,6 @@ import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -70,38 +69,38 @@ public class MemberService {
     return member;
   }
 
-  public List<MemberListReqDto> findMentors() {
+  public List<MemberListResDto> findMentors() {
     List<Member> mentors = memberRepository.findByRole(Role.MENTOR);
-    List<MemberListReqDto> memberListReqDtos = new ArrayList<>();
+    List<MemberListResDto> memberListResDtos = new ArrayList<>();
 
     for (Member m : mentors) {
-      MemberListReqDto memberListReqDto = new MemberListReqDto();
-      memberListReqDto.setId(m.getId());
-      memberListReqDto.setName(m.getName());
-      memberListReqDto.setEmail(m.getEmail());
-      memberListReqDto.setUnivName(m.getUnivName());
-      memberListReqDto.setMajor(m.getMajor());
-      memberListReqDtos.add(memberListReqDto);
+      MemberListResDto memberListResDto = new MemberListResDto();
+      memberListResDto.setId(m.getId());
+      memberListResDto.setName(m.getName());
+      memberListResDto.setEmail(m.getEmail());
+      memberListResDto.setUnivName(m.getUnivName());
+      memberListResDto.setMajor(m.getMajor());
+      memberListResDtos.add(memberListResDto);
     }
 
-    return memberListReqDtos;
+    return memberListResDtos;
   }
 
-  public List<MemberListReqDto> findMentees() {
+  public List<MemberListResDto> findMentees() {
     List<Member> mentees = memberRepository.findByRole(Role.MENTEE);
-    List<MemberListReqDto> memberListReqDtos = new ArrayList<>();
+    List<MemberListResDto> memberListResDtos = new ArrayList<>();
 
     for (Member m : mentees) {
-      MemberListReqDto memberListReqDto = new MemberListReqDto();
-      memberListReqDto.setId(m.getId());
-      memberListReqDto.setName(m.getName());
-      memberListReqDto.setEmail(m.getEmail());
-      memberListReqDto.setUnivName(m.getUnivName());
-      memberListReqDto.setMajor(m.getMajor());
-      memberListReqDtos.add(memberListReqDto);
+      MemberListResDto memberListResDto = new MemberListResDto();
+      memberListResDto.setId(m.getId());
+      memberListResDto.setName(m.getName());
+      memberListResDto.setEmail(m.getEmail());
+      memberListResDto.setUnivName(m.getUnivName());
+      memberListResDto.setMajor(m.getMajor());
+      memberListResDtos.add(memberListResDto);
     }
 
-    return memberListReqDtos;
+    return memberListResDtos;
   }
 
   public Member getMemberBySocialId(String socialId) {

--- a/goojakgyo/src/main/resources/application.yml
+++ b/goojakgyo/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
     generate-ddl: true
     hibernate:
       # ?? update or validate? ??
-      ddl-auto: validate
+      ddl-auto: update
     show_sql: true
 
 jwt:


### PR DESCRIPTION
## 📝작업 내용

<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->

- Keword Entity 생성 
  - Member Entity와 다대다 맵핑
- MemberSaveReqDto 수정
- OauthSaveReqDto 수정

</br>

- 일반 회원가입 및 OAuth 로그인 시 기존 회원이 아닐 때 회원 가입 페이지로 이동해서 관심 키워드를 선택 

</br> 

- 회원 생성 method 수정 
- 추가 정보 입력 후 회원 생성 method 구현 

</br>

- 회원목록 조회 기능 수정
  - 회원의 Role에 따라 분류하여 조회

</br>

- 회원목록에서 회원 이름을 클릭하면 그 회원의 프로필 정보를 다이알로그 형식으로 조회

<br/>

## 👀변경 사항

<!-- 컴포넌트, API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요 -->
- 다대다 맵핑을 위해 생성된 Entity들 확인 요망
  - Role default 없앰
  - ProfileImageUrl default 생성
- vue 업데이트
<br/>

## #️⃣관련 이슈

<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
- #15  