### PR TITLE
✨ [Feat] JWT Refresh Token 구현

### DIFF
--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/common/configs/RedisConfig.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/common/configs/RedisConfig.java
@@ -1,0 +1,29 @@
+package com.goojakgyo.goojakgyo.common.configs;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+
+  @Value("${spring.redis.host}")
+  private String host;
+
+  @Value("${spring.redis.port}")
+  private int port;
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration(host, port);
+
+    return new LettuceConnectionFactory(configuration);
+  }
+
+
+}

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/common/configs/SecurityConfigs.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/common/configs/SecurityConfigs.java
@@ -33,7 +33,7 @@ public class SecurityConfigs {
         .sessionManagement(s->s.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) //세션방식을 사용하지 않겠다라는 의미
         // 특정 url패턴에 대해서는 Authentication객체 요구하지 않음.(인증처리 제외)
         .authorizeHttpRequests(a -> a.requestMatchers("/member/create", "/member/doLogin",
-            "/member/google/doLogin", "/member/kakao/doLogin", "/member/naver/doLogin", "/member/oauth/create", "/connect/**").permitAll().anyRequest().authenticated())
+            "/member/google/doLogin", "/member/kakao/doLogin", "/member/naver/doLogin", "/member/oauth/create", "/member/reissue", "/connect/**").permitAll().anyRequest().authenticated())
         .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
         .build();
   }

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/common/earth/JwtTokenProvider.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/common/earth/JwtTokenProvider.java
@@ -1,6 +1,7 @@
 package com.goojakgyo.goojakgyo.common.earth;
 
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import java.security.Key;
@@ -13,18 +14,21 @@ import org.springframework.stereotype.Component;
 public class JwtTokenProvider {
 
   private final String secretKey;
-  private final int expiration;
+  private final int accessTokenExpiration;
+  private final int refreshTokenExpiration;
   private final Key SECRET_KEY;
 
-  public JwtTokenProvider(@Value("${jwt.secretKey}") String secretKey, @Value("${jwt.expiration}") int expiration) {
+  public JwtTokenProvider(@Value("${jwt.secretKey}") String secretKey, @Value("${jwt.access-expiration}") int accessTokenExpiration,
+      @Value("${jwt.refresh-expiration}") int refreshTokenExpiration) {
     this.secretKey = secretKey;
-    this.expiration = expiration;
+    this.accessTokenExpiration = accessTokenExpiration;
+    this.refreshTokenExpiration = refreshTokenExpiration;
     this.SECRET_KEY = new SecretKeySpec(java.util.Base64.getDecoder().decode(secretKey), SignatureAlgorithm.HS512.getJcaName());
   }
 
-  public String createToken(String email, String role) {
+  public String createToken(String email, String role, int expiration) {
     Claims claims = Jwts.claims().setSubject(email);
-    claims.put("role", role);
+    if (role!= null) claims.put("role", role);
     Date now = new Date();
 
     String token = Jwts.builder()
@@ -35,6 +39,32 @@ public class JwtTokenProvider {
         .compact();
 
     return token;
+  }
+
+  public String createAccessToken(String email, String role) {
+    return createToken(email, role, accessTokenExpiration);
+  }
+
+  public String createRefreshToken(String email) {
+    return createToken(email, null, refreshTokenExpiration);
+  }
+
+  public boolean validateToken(String token) {
+    try {
+      Jwts.parserBuilder().setSigningKey(SECRET_KEY).build().parseClaimsJws(token);
+      return true;
+    } catch (JwtException | IllegalArgumentException e) {
+      return false;
+    }
+  }
+
+  public String getEmailFromToken(String token) {
+    return Jwts.parserBuilder()
+        .setSigningKey(SECRET_KEY)
+        .build()
+        .parseClaimsJws(token)
+        .getBody()
+        .getSubject();
   }
 
 }

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/controller/MemberController.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/controller/MemberController.java
@@ -2,6 +2,7 @@ package com.goojakgyo.goojakgyo.member.controller;
 
 import com.goojakgyo.goojakgyo.common.earth.JwtTokenProvider;
 import com.goojakgyo.goojakgyo.member.domain.Member;
+import com.goojakgyo.goojakgyo.member.domain.RefreshToken;
 import com.goojakgyo.goojakgyo.member.domain.SocialType;
 import com.goojakgyo.goojakgyo.member.dto.AccessTokenDto;
 import com.goojakgyo.goojakgyo.member.dto.GoogleProfileDto;
@@ -13,15 +14,22 @@ import com.goojakgyo.goojakgyo.member.dto.MemberSaveReqDto;
 import com.goojakgyo.goojakgyo.member.dto.NaverProfileDto;
 import com.goojakgyo.goojakgyo.member.dto.OauthSaveReqDto;
 import com.goojakgyo.goojakgyo.member.dto.RedirectDto;
+import com.goojakgyo.goojakgyo.member.repository.RefreshTokenRepository;
 import com.goojakgyo.goojakgyo.member.service.GoogleService;
 import com.goojakgyo.goojakgyo.member.service.KakaoService;
 import com.goojakgyo.goojakgyo.member.service.MemberService;
 import com.goojakgyo.goojakgyo.member.service.NaverService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import java.net.URI;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -40,14 +48,17 @@ public class MemberController {
   private final GoogleService googleService;
   private final KakaoService kakaoService;
   private final NaverService naverService;
+  private final RefreshTokenRepository refreshTokenRepository;
 
   public MemberController(MemberService memberService, JwtTokenProvider jwtTokenProvider,
-      GoogleService googleService, KakaoService kakaoService, NaverService naverService) {
+      GoogleService googleService, KakaoService kakaoService, NaverService naverService,
+      RefreshTokenRepository refreshTokenRepository) {
     this.memberService = memberService;
     this.jwtTokenProvider = jwtTokenProvider;
     this.googleService = googleService;
     this.kakaoService = kakaoService;
     this.naverService = naverService;
+    this.refreshTokenRepository = refreshTokenRepository;
   }
 
   @PostMapping("/create")
@@ -59,13 +70,33 @@ public class MemberController {
   @PostMapping("/oauth/create")
   public ResponseEntity<?> oauthCreate(@RequestBody OauthSaveReqDto oauthSaveReqDto) {
     Member member = memberService.createOauth(oauthSaveReqDto);
-    String jwtToken = jwtTokenProvider.createToken(member.getEmail(), member.getRole().toString());
+
+    String accessToken = jwtTokenProvider.createAccessToken(member.getEmail(), member.getRole().toString());
+    String refreshToken = jwtTokenProvider.createRefreshToken(member.getEmail());
+
+    // Redis 저장
+    RefreshToken redisRefreshToken = RefreshToken.builder()
+        .memberId(member.getId())
+        .token(refreshToken)
+        .expiration(60 * 60 * 24 * 3 * 1000L)
+        .build();
+
+    refreshTokenRepository.save(redisRefreshToken);
+
+    ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+        .httpOnly(true)
+        .secure(false) // https 아니면 쿠키가 안들어가므로 개발중엔 false
+        .sameSite("Strict")
+        .path("/")
+        .maxAge(Duration.ofDays(3))
+        .build();
 
     Map<String, Object> loginInfo = new HashMap<>();
-    loginInfo.put("id", member.getId());
-    loginInfo.put("token", jwtToken);
+    loginInfo.put("memberId", member.getId());
+    loginInfo.put("accessToken", accessToken);
 
-    return new ResponseEntity<>(loginInfo, HttpStatus.CREATED);
+    URI location = URI.create("/member/" + member.getId());
+    return ResponseEntity.created(location).header(HttpHeaders.SET_COOKIE, cookie.toString()).body(loginInfo);
   }
 
   @PostMapping("/doLogin")
@@ -73,13 +104,32 @@ public class MemberController {
     // email, password 검증
     Member member = memberService.login(memberLoginReqDto);
 
-    // 일치할 경우 access token 발행
-    String jwtToken = jwtTokenProvider.createToken(member.getEmail(), member.getRole().toString());
-    Map<String, Object> loginInfo = new HashMap<>();
-    loginInfo.put("id", member.getId());
-    loginInfo.put("token", jwtToken);
+    // 일치할 경우 access token & refresh token 발행
+    String accessToken = jwtTokenProvider.createAccessToken(member.getEmail(), member.getRole().toString());
+    String refreshToken = jwtTokenProvider.createRefreshToken(member.getEmail());
 
-    return new ResponseEntity<>(loginInfo, HttpStatus.OK);
+    // Redis 저장
+    RefreshToken redisRefreshToken = RefreshToken.builder()
+        .memberId(member.getId())
+        .token(refreshToken)
+        .expiration(60 * 60 * 24 * 3 * 1000L)
+        .build();
+
+    refreshTokenRepository.save(redisRefreshToken);
+
+    ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+        .httpOnly(true)
+        .secure(false) // https 아니면 쿠키가 안들어가므로 개발중엔 false
+        .sameSite("Strict")
+        .path("/")
+        .maxAge(Duration.ofDays(3))
+        .build();
+
+    Map<String, Object> loginInfo = new HashMap<>();
+    loginInfo.put("memberId", member.getId());
+    loginInfo.put("accessToken", accessToken);
+
+    return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).body(loginInfo);
   }
 
   @PostMapping("/google/doLogin")
@@ -103,13 +153,32 @@ public class MemberController {
       return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    // 회원가입이 되어 있으면 Token 발급
-    String jwtToken = jwtTokenProvider.createToken(originalMember.getEmail(), originalMember.getRole().toString());
-    Map<String, Object> loginInfo = new HashMap<>();
-    loginInfo.put("id", originalMember.getId());
-    loginInfo.put("token", jwtToken);
+    // 회원가입이 되어 있으면 access token & refresh token 발급
+    String accessToken = jwtTokenProvider.createAccessToken(originalMember.getEmail(), originalMember.getRole().toString());
+    String refreshToken = jwtTokenProvider.createRefreshToken(originalMember.getEmail());
 
-    return new ResponseEntity<>(loginInfo, HttpStatus.OK);
+    // Redis 저장
+    RefreshToken redisRefreshToken = RefreshToken.builder()
+        .memberId(originalMember.getId())
+        .token(refreshToken)
+        .expiration(60 * 60 * 24 * 3 * 1000L)
+        .build();
+
+    refreshTokenRepository.save(redisRefreshToken);
+
+    ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+        .httpOnly(true)
+        .secure(false) // https 아니면 쿠키가 안들어가므로 개발중엔 false
+        .sameSite("Strict")
+        .path("/")
+        .maxAge(Duration.ofDays(3))
+        .build();
+
+    Map<String, Object> loginInfo = new HashMap<>();
+    loginInfo.put("memberId", originalMember.getId());
+    loginInfo.put("accessToken", accessToken);
+
+    return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).body(loginInfo);
   }
 
   @PostMapping("/kakao/doLogin")
@@ -133,13 +202,32 @@ public class MemberController {
       return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    // 회원가입이 되어 있으면 Token 발급
-    String jwtToken = jwtTokenProvider.createToken(originalMember.getEmail(), originalMember.getRole().toString());
-    Map<String, Object> loginInfo = new HashMap<>();
-    loginInfo.put("id", originalMember.getId());
-    loginInfo.put("token", jwtToken);
+    // 회원가입이 되어 있으면 access token & refresh token 발급
+    String accessToken = jwtTokenProvider.createAccessToken(originalMember.getEmail(), originalMember.getRole().toString());
+    String refreshToken = jwtTokenProvider.createRefreshToken(originalMember.getEmail());
 
-    return new ResponseEntity<>(loginInfo, HttpStatus.OK);
+    // Redis 저장
+    RefreshToken redisRefreshToken = RefreshToken.builder()
+        .memberId(originalMember.getId())
+        .token(refreshToken)
+        .expiration(60 * 60 * 24 * 3 * 1000L)
+        .build();
+
+    refreshTokenRepository.save(redisRefreshToken);
+
+    ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+        .httpOnly(true)
+        .secure(false) // https 아니면 쿠키가 안들어가므로 개발중엔 false
+        .sameSite("Strict")
+        .path("/")
+        .maxAge(Duration.ofDays(3))
+        .build();
+
+    Map<String, Object> loginInfo = new HashMap<>();
+    loginInfo.put("memberId", originalMember.getId());
+    loginInfo.put("accessToken", accessToken);
+
+    return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).body(loginInfo);
   }
 
   @PostMapping("/naver/doLogin")
@@ -163,13 +251,32 @@ public class MemberController {
       return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    // 회원 가입이 되어 있으면 Token 발급
-    String jwtToken = jwtTokenProvider.createToken(originalMember.getEmail(), originalMember.getRole().toString());
-    Map<String, Object> loginInfo = new HashMap<>();
-    loginInfo.put("id", originalMember.getId());
-    loginInfo.put("token", jwtToken);
+    // 회원 가입이 되어 있으면 access token & refresh token 발급
+    String accessToken = jwtTokenProvider.createAccessToken(originalMember.getEmail(), originalMember.getRole().toString());
+    String refreshToken = jwtTokenProvider.createRefreshToken(originalMember.getEmail());
 
-    return new ResponseEntity<>(loginInfo, HttpStatus.OK);
+    // Redis 저장
+    RefreshToken redisRefreshToken = RefreshToken.builder()
+        .memberId(originalMember.getId())
+        .token(refreshToken)
+        .expiration(60 * 60 * 24 * 3 * 1000L)
+        .build();
+
+    refreshTokenRepository.save(redisRefreshToken);
+
+    ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
+        .httpOnly(true)
+        .secure(false) // https 아니면 쿠키가 안들어가므로 개발중엔 false
+        .sameSite("Strict")
+        .path("/")
+        .maxAge(Duration.ofDays(3))
+        .build();
+
+    Map<String, Object> loginInfo = new HashMap<>();
+    loginInfo.put("memberId", originalMember.getId());
+    loginInfo.put("accessToken", accessToken);
+
+    return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).body(loginInfo);
   }
 
   @GetMapping("/list/mentor")
@@ -188,6 +295,83 @@ public class MemberController {
   public ResponseEntity<?> memberProfile(@PathVariable Long memberId) {
     MemberProfileResDto dto = memberService.getMemberProfile(memberId);
     return new ResponseEntity<>(dto, HttpStatus.OK);
+  }
+
+  @PostMapping("/reissue")
+  public ResponseEntity<?> reissue(HttpServletRequest request) {
+    // 쿠키에서 Refresh Token 추출
+    String refreshToken = null;
+    if (request.getCookies() != null) {
+      for (Cookie cookie : request.getCookies()) {
+        if ("refreshToken".equals(cookie.getName())) {
+          refreshToken = cookie.getValue();
+          break;
+        }
+      }
+    }
+
+    if (refreshToken == null) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("No Refresh Token in Cookie");
+    }
+
+    // Refresh Token 유효성 검증
+    if (!jwtTokenProvider.validateToken(refreshToken)) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Expired Refresh Token");
+    }
+
+    // Refresh Token에서 사용자 정보 추출
+    String email = jwtTokenProvider.getEmailFromToken(refreshToken);
+    Member member = memberService.getMemberByEmail(email);
+
+    // Redis에서 저장된 토큰 조회
+    RefreshToken storedToken = refreshTokenRepository.findById(member.getId())
+        .orElse(null);
+
+    if (storedToken == null || !storedToken.getToken().equals(refreshToken)) {
+      return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Invalid Refresh Token");
+    }
+
+    // 새로운 Access Token && Refresh Token 생성
+    String newAccessToken = jwtTokenProvider.createAccessToken(email, member.getRole().toString());
+    String newRefreshToken = jwtTokenProvider.createRefreshToken(email);
+
+    // 기존 refresh 토큰 갱신 (TTL 다시 설정됨)
+    storedToken.setToken(newRefreshToken);
+    storedToken.setExpiration(60 * 60 * 24 * 3 * 1000L);
+    refreshTokenRepository.save(storedToken);
+
+    // 새 Refresh Token을 쿠키로 재설정
+    ResponseCookie cookie = ResponseCookie.from("refreshToken", newRefreshToken)
+        .httpOnly(true)
+        .secure(false)
+        .sameSite("Strict")
+        .path("/")
+        .maxAge(Duration.ofDays(3))
+        .build();
+
+    Map<String, Object> token = new HashMap<>();
+    token.put("accessToken", newAccessToken);
+
+    return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).body(token);
+  }
+
+  @PostMapping("/logout")
+  public ResponseEntity<?> logout(@RequestBody Map<String, Long> request) {
+    Long memberId = request.get("memberId");
+
+    // Redis에서 Refresh Token 삭제
+    refreshTokenRepository.deleteById(memberId);
+
+    // 쿠키 즉시 만료
+    ResponseCookie cookie = ResponseCookie.from("refreshToken", "")
+        .httpOnly(true)
+        .secure(false)
+        .sameSite("Strict")
+        .path("/")
+        .maxAge(0)
+        .build();
+
+    return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).body("Logout Complete");
   }
 
 }

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/domain/RefreshToken.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/domain/RefreshToken.java
@@ -1,0 +1,26 @@
+package com.goojakgyo.goojakgyo.member.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.redis.core.TimeToLive;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@RedisHash(value = "refresh_token")
+public class RefreshToken {
+
+  // Redis key 역할
+  @Id
+  private Long memberId;
+
+  private String token;
+
+  @TimeToLive
+  private Long expiration;
+}

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/repository/RefreshTokenRepository.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/repository/RefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package com.goojakgyo.goojakgyo.member.repository;
+
+import com.goojakgyo.goojakgyo.member.domain.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
+
+}

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/service/MemberService.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/service/MemberService.java
@@ -147,4 +147,7 @@ public class MemberService {
         .build();
   }
 
+  public Member getMemberByEmail(String email) {
+    return memberRepository.findByEmail(email).orElse(null);
+  }
 }

--- a/goojakgyo/src/main/resources/application.yml
+++ b/goojakgyo/src/main/resources/application.yml
@@ -1,8 +1,11 @@
 
 spring:
+  redis:
+    host: localhost
+    port: 6379
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/goojakgyo?useSSL=false
+    url: jdbc:mysql://localhost:3306/goojakgyo?useSSL=false&allowPublicKeyRetrieval=true
     username: root
     password: 1234
   jpa:
@@ -18,7 +21,8 @@ spring:
 jwt:
   # goojakgyoaccesstokengoojakgyoaccesstokengoojakgyoaccesstokengoojakgyoaccesstoken
   secretKey: Z29vamFrZ3lvYWNjZXNzdG9rZW5nb29qYWtneW9hY2Nlc3N0b2tlbmdvb2pha2d5b2FjY2Vzc3Rva2VuZ29vamFrZ3lvYWNjZXNzdG9rZW4=
-  expiration: 3000 # 3000분
+  access-expiration: 30 # 30분
+  refresh-expiration: 4320 # 3일
 
 oauth:
   google:


### PR DESCRIPTION
## 📝작업 내용

<!-- 구현한 기능에 대한 구체적인 내용을 작성해주세요 -->

- Redis 의존성 추가 및 환경 설정
  - application.yml 설정 파일 수정 및 RedisConfig 설정 파일 생성

- Refresh Token 관리 로직 구현 
  - 로그인 시 Access Token과 Refresh Token 모두 발급
    - Refresh Token 쿠키 사용해서 보냄
  - RefreshToken 엔티티 및 RefreshRepository 구현
    - Redis를 사용하여 (key = memberId, value = refreshToken) 형태로 저장
    - TTL을 설정해서 자동 만료 관리

- Access Token 재발급 API 구현
  - /reissue 엔드포인트에서 Refresh Token 유효성 검증 후 새로운 Access Token 및 Refresh Token 발급
  - 기존 Redis에 저장된 Refresh Token 갱신 (Refresh Token을 탈취 당했을 때를 대비한 1회용 원칙)

- 로그아웃 API 구현
  - Redis에서 해당 사용자의 Refresh Token 삭제
  - Refresh Token이 담겨 있는 쿠키 초기화

- 위조 / 탈취 방지 로직
  - 저장된 Token과 요청받은 Token이 일치하지 않으면 401 UNAUTHORIZED 반환

<br/>

## 👀변경 사항

<!-- 컴포넌트, API, 로직 등 코드 변경으로 인해 협업 시 다른 개발자가 주의해야 할 내용이 있다면 작성해주세요 -->

- Redis 설정(RedisConfig) 생성으로 인해 Redis 서버 실행 필요
- application.yml에 Redis 연결 정보 추가
- Refresh Token 구현에 의한 기본 JWT 로그인 및 OAuth 로그인 로직 변경

<br/>

## #️⃣관련 이슈

<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
- #18 