### PR TITLE
🧩 [Fix] 1:1 채팅방 Displayname 수정, 채팅 시 Display 이메일 대신 이름으로 변경

### DIFF
--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/chat/domain/ChatParticipant.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/chat/domain/ChatParticipant.java
@@ -27,4 +27,7 @@ public class ChatParticipant extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    // 1대1 채팅일 때 상대방의 이름이 채팅방 이름이 되도록 (사용자 이름이 변경되지 않는다고 가정)
+    private String displayName;
 }

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/chat/dto/ChatMessageDto.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/chat/dto/ChatMessageDto.java
@@ -13,4 +13,5 @@ import lombok.NoArgsConstructor;
 public class ChatMessageDto {
     private String message;
     private String senderEmail;
+    private String senderName; // 보낸 사람 이름 추가
 }

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/chat/service/ChatService.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/chat/service/ChatService.java
@@ -88,6 +88,7 @@ public class ChatService {
         ChatParticipant chatParticipant = ChatParticipant.builder()
                 .chatRoom(chatRoom)
                 .member(member)
+                .displayName(chatRoomName) // 그룹채팅방일 땐 그대로 displayName 채팅방 이름으로 설정
                 .build();
         chatParticipantRepository.save(chatParticipant);
     }
@@ -126,15 +127,17 @@ public class ChatService {
         Optional<ChatParticipant> participant = chatParticipantRepository.findByChatRoomAndMember(chatRoom, member);
 
         if (!participant.isPresent()) {
-            addParticipantToRoom(chatRoom, member);
+            addParticipantToRoom(chatRoom, member, chatRoom.getName());
         }
     }
 
     // ChatParticipant 객체 생성 후 저장
-    public void addParticipantToRoom(ChatRoom chatRoom, Member member) {
+    // 표시되어야 할 채팅방 이름 파라미터에 추가
+    public void addParticipantToRoom(ChatRoom chatRoom, Member member, String roomName) {
         ChatParticipant chatParticipant = ChatParticipant.builder()
                 .chatRoom(chatRoom)
                 .member(member)
+                .displayName(roomName)
                 .build();
         chatParticipantRepository.save(chatParticipant);
     }
@@ -208,9 +211,10 @@ public class ChatService {
         // 현재 참여자가 속해있는 채팅방에서 읽지 않은 메시지의 개수 구하기
         for (ChatParticipant c : chatParticipants) {
             Long count = readStatusRepository.countByChatRoomAndMemberAndIsReadFalse(c.getChatRoom(), member);
+            String roomDisplayName = c.getDisplayName();
             MyChatListResDto dto = MyChatListResDto.builder()
                     .roomId(c.getChatRoom().getId())
-                    .roomName(c.getChatRoom().getName())
+                    .roomName(roomDisplayName) // DisplayName 띄우는 것으로 변경
                     .isGroupChat(c.getChatRoom().getIsGroupChat())
                     .unReadCount(count)
                     .build();
@@ -262,13 +266,13 @@ public class ChatService {
         // 만약에 1:1 채팅방이 없을 경우 새로운 채팅방 개설
         ChatRoom newRoom = ChatRoom.builder()
                 .isGroupChat("N")
-                .name(otherMember.getName())
+                .name(member.getName() + "-" + otherMember.getName())
                 .build();
         chatRoomRepository.save(newRoom);
 
         // 두 사람 모두 참여자로 새롭게 추가
-        addParticipantToRoom(newRoom, member);
-        addParticipantToRoom(newRoom, otherMember);
+        addParticipantToRoom(newRoom, member, otherMember.getName());
+        addParticipantToRoom(newRoom, otherMember, member.getName());
 
         return newRoom.getId();
     }

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/chat/service/ChatService.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/chat/service/ChatService.java
@@ -166,6 +166,7 @@ public class ChatService {
             ChatMessageDto chatMessageDto = ChatMessageDto.builder()
                     .message(c.getContent())
                     .senderEmail(c.getMember().getEmail())
+                    .senderName(c.getMember().getName()) // 이전 메시지 읽어올 때 보낸 사람 이름 정보도 같이 보냄
                     .build();
             chatMessageDtos.add(chatMessageDto);
         }

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/common/earth/JwtTokenProvider.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/common/earth/JwtTokenProvider.java
@@ -26,9 +26,11 @@ public class JwtTokenProvider {
     this.SECRET_KEY = new SecretKeySpec(java.util.Base64.getDecoder().decode(secretKey), SignatureAlgorithm.HS512.getJcaName());
   }
 
-  public String createToken(String email, String role, int expiration) {
+  // 토큰 생성 시 이름도 함께 넘기도록
+  public String createToken(String email, String name, String role, int expiration) {
     Claims claims = Jwts.claims().setSubject(email);
     if (role!= null) claims.put("role", role);
+    if (name != null) claims.put("name", name);
     Date now = new Date();
 
     String token = Jwts.builder()
@@ -41,12 +43,12 @@ public class JwtTokenProvider {
     return token;
   }
 
-  public String createAccessToken(String email, String role) {
-    return createToken(email, role, accessTokenExpiration);
+  public String createAccessToken(String email, String name, String role) {
+    return createToken(email, name, role, accessTokenExpiration);
   }
 
-  public String createRefreshToken(String email) {
-    return createToken(email, null, refreshTokenExpiration);
+  public String createRefreshToken(String email, String name) {
+    return createToken(email, name, null, refreshTokenExpiration);
   }
 
   public boolean validateToken(String token) {

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/common/earth/JwtTokenProvider.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/common/earth/JwtTokenProvider.java
@@ -26,11 +26,9 @@ public class JwtTokenProvider {
     this.SECRET_KEY = new SecretKeySpec(java.util.Base64.getDecoder().decode(secretKey), SignatureAlgorithm.HS512.getJcaName());
   }
 
-  // 토큰 생성 시 이름도 함께 넘기도록
-  public String createToken(String email, String name, String role, int expiration) {
+  public String createToken(String email, String role, int expiration) {
     Claims claims = Jwts.claims().setSubject(email);
     if (role!= null) claims.put("role", role);
-    if (name != null) claims.put("name", name);
     Date now = new Date();
 
     String token = Jwts.builder()
@@ -43,12 +41,12 @@ public class JwtTokenProvider {
     return token;
   }
 
-  public String createAccessToken(String email, String name, String role) {
-    return createToken(email, name, role, accessTokenExpiration);
+  public String createAccessToken(String email, String role) {
+    return createToken(email, role, accessTokenExpiration);
   }
 
-  public String createRefreshToken(String email, String name) {
-    return createToken(email, name, null, refreshTokenExpiration);
+  public String createRefreshToken(String email) {
+    return createToken(email, null, refreshTokenExpiration);
   }
 
   public boolean validateToken(String token) {

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/controller/MemberController.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/controller/MemberController.java
@@ -71,8 +71,8 @@ public class MemberController {
   public ResponseEntity<?> oauthCreate(@RequestBody OauthSaveReqDto oauthSaveReqDto) {
     Member member = memberService.createOauth(oauthSaveReqDto);
 
-    String accessToken = jwtTokenProvider.createAccessToken(member.getEmail(), member.getRole().toString());
-    String refreshToken = jwtTokenProvider.createRefreshToken(member.getEmail());
+    String accessToken = jwtTokenProvider.createAccessToken(member.getEmail(), member.getName(), member.getRole().toString());
+    String refreshToken = jwtTokenProvider.createRefreshToken(member.getEmail(), member.getName());
 
     // Redis 저장
     RefreshToken redisRefreshToken = RefreshToken.builder()
@@ -94,6 +94,7 @@ public class MemberController {
     Map<String, Object> loginInfo = new HashMap<>();
     loginInfo.put("memberId", member.getId());
     loginInfo.put("accessToken", accessToken);
+    loginInfo.put("name", member.getName());
 
     URI location = URI.create("/member/" + member.getId());
     return ResponseEntity.created(location).header(HttpHeaders.SET_COOKIE, cookie.toString()).body(loginInfo);
@@ -105,8 +106,8 @@ public class MemberController {
     Member member = memberService.login(memberLoginReqDto);
 
     // 일치할 경우 access token & refresh token 발행
-    String accessToken = jwtTokenProvider.createAccessToken(member.getEmail(), member.getRole().toString());
-    String refreshToken = jwtTokenProvider.createRefreshToken(member.getEmail());
+    String accessToken = jwtTokenProvider.createAccessToken(member.getEmail(), member.getName(), member.getRole().toString());
+    String refreshToken = jwtTokenProvider.createRefreshToken(member.getEmail(), member.getName());
 
     // Redis 저장
     RefreshToken redisRefreshToken = RefreshToken.builder()
@@ -128,6 +129,7 @@ public class MemberController {
     Map<String, Object> loginInfo = new HashMap<>();
     loginInfo.put("memberId", member.getId());
     loginInfo.put("accessToken", accessToken);
+    loginInfo.put("name", member.getName());
 
     return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).body(loginInfo);
   }
@@ -154,8 +156,8 @@ public class MemberController {
     }
 
     // 회원가입이 되어 있으면 access token & refresh token 발급
-    String accessToken = jwtTokenProvider.createAccessToken(originalMember.getEmail(), originalMember.getRole().toString());
-    String refreshToken = jwtTokenProvider.createRefreshToken(originalMember.getEmail());
+    String accessToken = jwtTokenProvider.createAccessToken(originalMember.getEmail(), originalMember.getName(), originalMember.getRole().toString());
+    String refreshToken = jwtTokenProvider.createRefreshToken(originalMember.getEmail(), originalMember.getName());
 
     // Redis 저장
     RefreshToken redisRefreshToken = RefreshToken.builder()
@@ -177,6 +179,7 @@ public class MemberController {
     Map<String, Object> loginInfo = new HashMap<>();
     loginInfo.put("memberId", originalMember.getId());
     loginInfo.put("accessToken", accessToken);
+    loginInfo.put("name", originalMember.getName());
 
     return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).body(loginInfo);
   }
@@ -203,8 +206,8 @@ public class MemberController {
     }
 
     // 회원가입이 되어 있으면 access token & refresh token 발급
-    String accessToken = jwtTokenProvider.createAccessToken(originalMember.getEmail(), originalMember.getRole().toString());
-    String refreshToken = jwtTokenProvider.createRefreshToken(originalMember.getEmail());
+    String accessToken = jwtTokenProvider.createAccessToken(originalMember.getEmail(), originalMember.getName(), originalMember.getRole().toString());
+    String refreshToken = jwtTokenProvider.createRefreshToken(originalMember.getEmail(), originalMember.getName());
 
     // Redis 저장
     RefreshToken redisRefreshToken = RefreshToken.builder()
@@ -226,6 +229,7 @@ public class MemberController {
     Map<String, Object> loginInfo = new HashMap<>();
     loginInfo.put("memberId", originalMember.getId());
     loginInfo.put("accessToken", accessToken);
+    loginInfo.put("name", originalMember.getName());
 
     return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).body(loginInfo);
   }
@@ -252,8 +256,8 @@ public class MemberController {
     }
 
     // 회원 가입이 되어 있으면 access token & refresh token 발급
-    String accessToken = jwtTokenProvider.createAccessToken(originalMember.getEmail(), originalMember.getRole().toString());
-    String refreshToken = jwtTokenProvider.createRefreshToken(originalMember.getEmail());
+    String accessToken = jwtTokenProvider.createAccessToken(originalMember.getEmail(), originalMember.getName(), originalMember.getRole().toString());
+    String refreshToken = jwtTokenProvider.createRefreshToken(originalMember.getEmail(), originalMember.getName());
 
     // Redis 저장
     RefreshToken redisRefreshToken = RefreshToken.builder()
@@ -275,6 +279,7 @@ public class MemberController {
     Map<String, Object> loginInfo = new HashMap<>();
     loginInfo.put("memberId", originalMember.getId());
     loginInfo.put("accessToken", accessToken);
+    loginInfo.put("name", originalMember.getName());
 
     return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, cookie.toString()).body(loginInfo);
   }
@@ -332,8 +337,8 @@ public class MemberController {
     }
 
     // 새로운 Access Token && Refresh Token 생성
-    String newAccessToken = jwtTokenProvider.createAccessToken(email, member.getRole().toString());
-    String newRefreshToken = jwtTokenProvider.createRefreshToken(email);
+    String newAccessToken = jwtTokenProvider.createAccessToken(email, member.getName(), member.getRole().toString());
+    String newRefreshToken = jwtTokenProvider.createRefreshToken(email, member.getName());
 
     // 기존 refresh 토큰 갱신 (TTL 다시 설정됨)
     storedToken.setToken(newRefreshToken);

--- a/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/controller/MemberController.java
+++ b/goojakgyo/src/main/java/com/goojakgyo/goojakgyo/member/controller/MemberController.java
@@ -71,8 +71,8 @@ public class MemberController {
   public ResponseEntity<?> oauthCreate(@RequestBody OauthSaveReqDto oauthSaveReqDto) {
     Member member = memberService.createOauth(oauthSaveReqDto);
 
-    String accessToken = jwtTokenProvider.createAccessToken(member.getEmail(), member.getName(), member.getRole().toString());
-    String refreshToken = jwtTokenProvider.createRefreshToken(member.getEmail(), member.getName());
+    String accessToken = jwtTokenProvider.createAccessToken(member.getEmail(), member.getRole().toString());
+    String refreshToken = jwtTokenProvider.createRefreshToken(member.getEmail());
 
     // Redis 저장
     RefreshToken redisRefreshToken = RefreshToken.builder()
@@ -106,8 +106,8 @@ public class MemberController {
     Member member = memberService.login(memberLoginReqDto);
 
     // 일치할 경우 access token & refresh token 발행
-    String accessToken = jwtTokenProvider.createAccessToken(member.getEmail(), member.getName(), member.getRole().toString());
-    String refreshToken = jwtTokenProvider.createRefreshToken(member.getEmail(), member.getName());
+    String accessToken = jwtTokenProvider.createAccessToken(member.getEmail(), member.getRole().toString());
+    String refreshToken = jwtTokenProvider.createRefreshToken(member.getEmail());
 
     // Redis 저장
     RefreshToken redisRefreshToken = RefreshToken.builder()
@@ -156,8 +156,8 @@ public class MemberController {
     }
 
     // 회원가입이 되어 있으면 access token & refresh token 발급
-    String accessToken = jwtTokenProvider.createAccessToken(originalMember.getEmail(), originalMember.getName(), originalMember.getRole().toString());
-    String refreshToken = jwtTokenProvider.createRefreshToken(originalMember.getEmail(), originalMember.getName());
+    String accessToken = jwtTokenProvider.createAccessToken(originalMember.getEmail(), originalMember.getRole().toString());
+    String refreshToken = jwtTokenProvider.createRefreshToken(originalMember.getEmail());
 
     // Redis 저장
     RefreshToken redisRefreshToken = RefreshToken.builder()
@@ -206,8 +206,8 @@ public class MemberController {
     }
 
     // 회원가입이 되어 있으면 access token & refresh token 발급
-    String accessToken = jwtTokenProvider.createAccessToken(originalMember.getEmail(), originalMember.getName(), originalMember.getRole().toString());
-    String refreshToken = jwtTokenProvider.createRefreshToken(originalMember.getEmail(), originalMember.getName());
+    String accessToken = jwtTokenProvider.createAccessToken(originalMember.getEmail(), originalMember.getRole().toString());
+    String refreshToken = jwtTokenProvider.createRefreshToken(originalMember.getEmail());
 
     // Redis 저장
     RefreshToken redisRefreshToken = RefreshToken.builder()
@@ -256,8 +256,8 @@ public class MemberController {
     }
 
     // 회원 가입이 되어 있으면 access token & refresh token 발급
-    String accessToken = jwtTokenProvider.createAccessToken(originalMember.getEmail(), originalMember.getName(), originalMember.getRole().toString());
-    String refreshToken = jwtTokenProvider.createRefreshToken(originalMember.getEmail(), originalMember.getName());
+    String accessToken = jwtTokenProvider.createAccessToken(originalMember.getEmail(), originalMember.getRole().toString());
+    String refreshToken = jwtTokenProvider.createRefreshToken(originalMember.getEmail());
 
     // Redis 저장
     RefreshToken redisRefreshToken = RefreshToken.builder()
@@ -337,8 +337,8 @@ public class MemberController {
     }
 
     // 새로운 Access Token && Refresh Token 생성
-    String newAccessToken = jwtTokenProvider.createAccessToken(email, member.getName(), member.getRole().toString());
-    String newRefreshToken = jwtTokenProvider.createRefreshToken(email, member.getName());
+    String newAccessToken = jwtTokenProvider.createAccessToken(email, member.getRole().toString());
+    String newRefreshToken = jwtTokenProvider.createRefreshToken(email);
 
     // 기존 refresh 토큰 갱신 (TTL 다시 설정됨)
     storedToken.setToken(newRefreshToken);


### PR DESCRIPTION
## 📝작업 내용

- 1 : 1 채팅시 채팅방 이름 상대방 이름으로 설정
- 채팅 진행 시 보낸 사람 정보 이메일 -> 이름 & 이메일로 변경

<br/>

## 👀변경 사항

Member 파트 코드 일부 수정
- JwtTokenProvider
- MemberController



<br/>

## #️⃣관련 이슈

<!-- 해당 PR과 관련된 이슈 번호가 있다면 "- #22" 형태로 작성해주세요 -->
#20 